### PR TITLE
Remove broken GitHub Streak image

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,6 @@ From Camus to code, I maintain a healthy balance between philosophical inquiry a
 
 <div align="center">
 
-<!-- GitHub Streak Stats -->
-<a href="https://github.com/AvanAvi">
-  <img src="https://streak-stats.demolab.com/?user=AvanAvi&theme=github-dark-blue&hide_border=true&background=0D1117&stroke=58A6FF&ring=58A6FF&fire=FF6B35&currStreakLabel=58A6FF&sideLabels=58A6FF&currStreakNum=FFFFFF&sideNums=FFFFFF&dates=8B949E" alt="GitHub Streak" />
-</a>
-
-<br/><br/>
-
 <!-- Activity Graph -->
 <a href="https://github.com/AvanAvi">
   <img src="https://github-readme-activity-graph.vercel.app/graph?username=AvanAvi&bg_color=0D1117&color=58A6FF&line=FF6B35&point=FFFFFF&area=true&area_color=58A6FF&hide_border=true&custom_title=Contribution%20Activity%20Timeline" alt="Activity Graph" />


### PR DESCRIPTION
The streak-stats.demolab.com service is returning broken images, causing a broken image placeholder to display in the profile.